### PR TITLE
Dirty hacks to make this compile on ubuntu 14.04 and ros indigo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.4.6)
 #########################################################
 ### USER CONFIG #########################################
 #########################################################
-set(USE_SIFT_GPU        1) 
+set(USE_SIFT_GPU        0) 
 set(ENV{SIFT_GPU_MODE}	2) #CUDA = 1, GLSL = 2
 set(ENV{SIFT_GPU_CUDA_PATH}	/usr/local/cuda)	
 set(USE_GICP_BIN		0)
@@ -18,7 +18,8 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 #SET(CMAKE_CXX_FLAGS "-O3 -fPIC -std=c++0x")
 #For annotated profiling with perf: 
-SET(CMAKE_CXX_FLAGS "-ggdb -O3 -fPIC -std=c++0x")
+#SET(CMAKE_CXX_FLAGS "-ggdb -O3 -fPIC -std=c++0x")
+SET(CMAKE_CXX_FLAGS "-ggdb -O3 -fPIC")
 
 IF (${USE_GL2PS})
   add_definitions(-DGL2PS)

--- a/src/feature_adjuster.cpp
+++ b/src/feature_adjuster.cpp
@@ -200,7 +200,7 @@ VideoGridAdaptedFeatureDetector::VideoGridAdaptedFeatureDetector( const cv::Ptr<
 
 bool VideoGridAdaptedFeatureDetector::empty() const
 {
-    for(auto detector : detectors){
+    for(std::vector<cv::Ptr<StatefulFeatureDetector> >::const_iterator detector = detectors.begin(); detector != detectors.end(); ++detector){
       if(detector->empty()) return true;
     }
     return false;

--- a/src/openni_listener.cpp
+++ b/src/openni_listener.cpp
@@ -269,8 +269,9 @@ void OpenNIListener::loadBag(std::string filename)
         if (tf_msg) {
           //if(tf_msg->transforms[0].header.frame_id == "/kinect") continue;//avoid destroying tf tree if odom is used
           //prevents missing callerid warning
-          boost::shared_ptr<std::map<std::string, std::string> > msg_header_map = tf_msg->__connection_header;
-          (*msg_header_map)["callerid"] = "rgbdslam";
+          //TODO This is a dirty hack as __connection header does not seem to be available
+          //boost::shared_ptr<std::map<std::string, std::string> > msg_header_map = tf_msg->__connection_header;
+          //(*msg_header_map)["callerid"] = "rgbdslam";
           tf_pub_.publish(tf_msg);
           ROS_DEBUG("Found Message of %s", tf_tpc.c_str());
           last_tf = tf_msg->transforms[0].header.stamp;


### PR DESCRIPTION
These were the changes that I needed to make this compile and work on ubuntu 14.04 and ros indigo. The -std=c++0 needed to be removed as the PCL libraries were segfaulting with this option. 
This resulted on the auto type seen in feature_adjuster to break, so it is replaced with its real type.

I also had to comment out the tf_msg->__connection_header; as it seems that it does not exist anymore (this seemd to have some proper fix on the odometry branch).

Disabling the USE_SIFT_GPU is most likely not neccessary on most systems.
