### PR TITLE
Modifications to build code on Indigo without segfaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 #SET(CMAKE_CXX_FLAGS "-O3 -fPIC -std=c++0x")
 #For annotated profiling with perf: 
-SET(CMAKE_CXX_FLAGS "-ggdb -O3 -fPIC -std=c++0x")
-
+#SET(CMAKE_CXX_FLAGS "-ggdb -O3 -fPIC -std=c++0x")
+SET(CMAKE_CXX_FLAGS "-ggdb -O3 -fPIC")
 IF (${USE_GL2PS})
   add_definitions(-DGL2PS)
 ENDIF (${USE_GL2PS})
@@ -40,7 +40,7 @@ ENDIF (${USE_GICP_BIN} OR ${USE_GICP_CODE})
 ####################################################
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules/")
 #message(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
-find_package(catkin REQUIRED COMPONENTS pcl_conversions pcl_ros roscpp image_transport cv_bridge sensor_msgs 
+find_package(catkin REQUIRED COMPONENTS pcl_conversions pcl_ros roscpp image_transport cv_bridge sensor_msgs cmake_modules
              geometry_msgs visualization_msgs std_msgs tf message_generation message_filters rosbag rosconsole)
 
 project(rgbdslam)
@@ -169,6 +169,7 @@ ENDIF (${USE_PCL_ICP})
 #############################
 # OpenCV ####################
 #############################
+set(OpenCV_DIR $ENV{OpenCV_DIR})
 find_package(OpenCV)
 include_directories(${OpenCV_INCLUDE_DIRS})
 link_directories(${OpenCV_LIBRARY_DIRS})
@@ -225,7 +226,7 @@ add_dependencies(rgbdslam rgbdslam_gencpp)
 #SET(G2O_LIBS ${G2O_LIBRARIES} cholmod cxsparse)
 #SET(LIBS_LINK GL GLU -lgl2ps ${G2O_LIBS} ${QT_LIBRARIES} ${QT_QTOPENGL_LIBRARY} ${GLUT_LIBRARY} ${OPENGL_LIBRARY} ${OpenCV_LIBS})
 #Use specific version of cxsparse, to avoid linker warning about possible conflicts between versions 2.2.3 (linked from g2o) and 3.1.0
-SET(LIBS_LINK GL GLU cholmod /usr/lib/libcxsparse.so.2.2.3 ${G2O_LIBRARIES} ${QT_LIBRARIES} ${QT_QTOPENGL_LIBRARY} ${GLUT_LIBRARY} ${OPENGL_LIBRARY} ${OpenCV_LIBS})
+SET(LIBS_LINK GL GLU cholmod cxsparse ${G2O_LIBRARIES} ${QT_LIBRARIES} ${QT_QTOPENGL_LIBRARY} ${GLUT_LIBRARY} ${OPENGL_LIBRARY} ${OpenCV_LIBS})
 #-lboost_signals -lrt -loctomap -loctomap_server -loctomath)
 
 IF (${USE_SIFT_GPU})

--- a/package.xml
+++ b/package.xml
@@ -48,7 +48,8 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>octomap</build_depend>
-  <build_depend>visualization_msgs</build_depend>
+  <build_depend>visualization_msgs</build_depend> 
+  <build_depend>cmake_modules</build_depend>
   <run_depend>pcl_conversions</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>roscpp</run_depend>
@@ -56,7 +57,9 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>visualization_msgs</run_depend>
+  <run_depend>cmake_modules</run_depend>
   <!-- own stuff -->
+
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>libg2o</build_depend>

--- a/src/feature_adjuster.cpp
+++ b/src/feature_adjuster.cpp
@@ -200,8 +200,8 @@ VideoGridAdaptedFeatureDetector::VideoGridAdaptedFeatureDetector( const cv::Ptr<
 
 bool VideoGridAdaptedFeatureDetector::empty() const
 {
-    for(auto detector : detectors){
-      if(detector->empty()) return true;
+    for(std::vector<cv::Ptr<StatefulFeatureDetector> >::const_iterator it = detectors.begin(); it != detectors.end(); ++it){
+      if((*it)->empty()) return true;
     }
     return false;
 }

--- a/src/openni_listener.cpp
+++ b/src/openni_listener.cpp
@@ -269,8 +269,8 @@ void OpenNIListener::loadBag(std::string filename)
         if (tf_msg) {
           //if(tf_msg->transforms[0].header.frame_id == "/kinect") continue;//avoid destroying tf tree if odom is used
           //prevents missing callerid warning
-          boost::shared_ptr<std::map<std::string, std::string> > msg_header_map = tf_msg->__connection_header;
-          (*msg_header_map)["callerid"] = "rgbdslam";
+          // boost::shared_ptr<std::map<std::string, std::string> > msg_header_map = tf_msg->__connection_header;
+          // (*msg_header_map)["callerid"] = "rgbdslam";
           tf_pub_.publish(tf_msg);
           ROS_DEBUG("Found Message of %s", tf_tpc.c_str());
           last_tf = tf_msg->transforms[0].header.stamp;


### PR DESCRIPTION
There's a hardcoded cxsparse library link which is fixed. Connection header has been deprecated. For non-free OpenCV errors using GPU SIFT, set the OpenCV_DIR environment variable to point to user compiled OpenCV path.
