### PR TITLE
Removed dependency on nonfree OpenCV modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(USE_GICP 0)
 IF (${USE_GICP_BIN} OR ${USE_GICP_CODE})
 	set(USE_GICP 1)
 ENDIF (${USE_GICP_BIN} OR ${USE_GICP_CODE})
+
 #########################################################
 #########################################################
 
@@ -169,8 +170,18 @@ ENDIF (${USE_PCL_ICP})
 #############################
 # OpenCV ####################
 #############################
+#For using SIFT and SURF provide your own opencv installation
+#via exporting a shell variable
 set(OpenCV_DIR $ENV{OpenCV_DIR})
-#set(OpenCV_DIR /home/felix/ros_indigo/opencv2/build/)
+#or set it directly here, e.g.
+#set(OpenCV_DIR /home/endres/ros_indigo/opencv2/build/)
+#Then activate the following definition
+#add_definitions(-DCV_NONFREE)
+
+IF (NOT "${OpenCV_DIR}" EQUAL "")
+    MESSAGE("Using OpenCV from " ${OpenCV_DIR})
+ENDIF (NOT "${OpenCV_DIR}" EQUAL "")
+
 find_package(OpenCV)
 include_directories(${OpenCV_INCLUDE_DIRS})
 link_directories(${OpenCV_LIBRARY_DIRS})

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,9 @@
 #include "opencv2/core/core.hpp"
 #include "opencv2/features2d/features2d.hpp"
 #include "opencv2/highgui/highgui.hpp"
+#ifdef CV_NONFREE
 #include "opencv2/nonfree/nonfree.hpp"
+#endif
 #endif
 #include "aorb.h"
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,9 +37,6 @@
 #include "opencv2/core/core.hpp"
 #include "opencv2/features2d/features2d.hpp"
 #include "opencv2/highgui/highgui.hpp"
-#ifdef CV_NONFREE
-#include "opencv2/nonfree/nonfree.hpp"
-#endif
 #endif
 #include "aorb.h"
 


### PR DESCRIPTION
ROS Indigo on Ubuntu 14.04 by default only ship the free modules
of OpenCV. Since ORB provides a much better performance 
cost-benefit ratio I set the default build to use ORB  and omit
the dependency on the non-free modules. 

Nonfree OpenCV can be enabled in the CMakeLists.txt.
