### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This is a canonical way, feel free to adapt if you known what you are doing.
    If you get an error about the missing siftgpu library, execute "catkin_make" again.
 
 
-##Installation from Scratch #####################################################
+## Installation from Scratch  #####################################################
 There is now an install.sh script, which can be executed (`bash install.sh`).
 It installs everything required below ~/Code (you can change the location in the script).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
