### PR TITLE
Add some critical dependency installations for g2o

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,10 @@ echo "Updating ROS dependency database"
 echo
 rosdep update
 
+echo "Install dependences for g2o"
+sudo apt-get install libsuitesparse-dev libeigen3-dev
+echo
+
 echo
 echo "Downloading, building and installing g2o"
 echo


### PR DESCRIPTION
These installations may save lots of time for the users and developers.
They are necessary and sufficient for building rgbdslam_v2